### PR TITLE
Expose more specialized deserializers for nefarious ends

### DIFF
--- a/kaydle/src/serde/de.rs
+++ b/kaydle/src/serde/de.rs
@@ -254,4 +254,6 @@ pub fn from_str<'a, T: de::Deserialize<'a>>(input: &'a str) -> Result<T, Error> 
     T::deserialize(deserializer)
 }
 
+pub use anonymous_node::Deserializer as AnonymousNodeDeserializer;
+pub use named_node::Deserializer as NamedNodeDeserializer;
 pub use node_list::Deserializer;

--- a/kaydle/src/serde/de/anonymous_node.rs
+++ b/kaydle/src/serde/de/anonymous_node.rs
@@ -12,14 +12,24 @@ use super::{
     value::Deserializer as ValueDeserializer, Error,
 };
 
+/// Deserializer for an anonymous node.
 #[derive(Debug)]
 pub struct Deserializer<'i, 'p> {
     node: Annotated<'i, NodeContent<'i, 'p>>,
 }
 
 impl<'i, 'p> Deserializer<'i, 'p> {
+    /// Create a new Deserializer for a node with possible annotation.
     pub fn new(node: Annotated<'i, NodeContent<'i, 'p>>) -> Self {
         Self { node }
+    }
+
+    /// Create a Deserializer for an unannotated node.
+    pub fn new_unannotated(node: NodeContent<'i, 'p>) -> Self {
+        Self::new(Annotated {
+            item: node,
+            annotation: None,
+        })
     }
 
     /// Deserialize a single primitive value, like a number, string, unit,

--- a/kaydle/src/serde/de/named_node.rs
+++ b/kaydle/src/serde/de/named_node.rs
@@ -10,14 +10,24 @@ use super::{
     string::Deserializer as StringDeserializer, Error,
 };
 
+/// Deserializer for a named node.
 #[derive(Debug)]
 pub struct Deserializer<'i, 'p> {
     node: Annotated<'i, Node<'i, 'p, KdlString<'i>>>,
 }
 
 impl<'i, 'p> Deserializer<'i, 'p> {
+    /// Create a new Deserializer for a node with possible annotation.
     pub fn new(node: Annotated<'i, Node<'i, 'p, KdlString<'i>>>) -> Self {
         Self { node }
+    }
+
+    /// Create a Deserializer for an unannotated node.
+    pub fn new_unannotated(node: Node<'i, 'p, KdlString<'i>>) -> Self {
+        Self::new(Annotated {
+            item: node,
+            annotation: None,
+        })
     }
 
     /// Extract the name from `self.node` and return the rest of it as an


### PR DESCRIPTION
Hello, I am writing a blueprint/object instantiation system for my entity-component-message crate [Palkia](https://crates.io/crates/palkia). To that end I'd like to be able to directly deserialize anonymous nodes as structs. 

The plan is to be able to load blueprints from files; each blueprint looks like 

```kdl
blueprint-name {
  component1 key="value" key2="value2"
  component2 key="value"
}

blueprint-2 {
  ...
}

blueprint-3 inherit="blueprint-2" {
  another-component key="value"
}

blueprint-name merge="merge" {
  component2 key="different-value"
}

...
```

So, each component entry I'd like to be able to deserialize to a struct ... meaning I need the anonymous struct deserializer exposed.